### PR TITLE
Remove 'Resource Group' from Networking list

### DIFF
--- a/sap-environment-vpc-infrastructure.md
+++ b/sap-environment-vpc-infrastructure.md
@@ -54,7 +54,6 @@ The {{site.data.keyword.vpc_short}} infrastructure network, is robust, secure, a
 | {{site.data.keyword.cloud_notm}} VPC Infrastructure network |
 | -- |
 | Global |
-| Resource Group |
 | Region |
 | VPC |
 | Availability zone (with address prefix) |


### PR DESCRIPTION
A resource group is not a networking component of VPC, it's a construct of IAM that separates resources and allows permissioned access. Different resources in a VPC can exist in different Resource Groups too. Resource Groups are not referred to again in the text below the table, so I think it should be removed to avoid confusion.